### PR TITLE
Keep versions in DOIs (preprints)

### DIFF
--- a/pkg/federated_search.go
+++ b/pkg/federated_search.go
@@ -147,10 +147,7 @@ func extractDOI(doi string) string {
 		slog.Debug(fmt.Sprintf("String is not a valid doi: %s", doi))
 		return doi
 	}
-	endInd := len(doi) - (strings.Index(reverse(doi), "v") + 1)
-	if (endInd < startInd) {
-		endInd = len(doi)
-	}
+	endInd := len(doi)
 	doiNum := doi[startInd:endInd]
 	doiNum = strings.Replace(doiNum, "(", "\\(", -1)
 	doiNum = strings.Replace(doiNum, ")", "\\)", -1)

--- a/pkg/federated_search_test.go
+++ b/pkg/federated_search_test.go
@@ -98,7 +98,7 @@ func MockPostToFieldSearch(c *gin.Context) {
 func TestExtractDOI(t *testing.T) {
 	doi := "https://doi.org/10.1010/a11-22(22)33v3"
 	extracted := extractDOI(doi)
-	expected := "10.1010/a11-22\\(22\\)33"
+	expected := "10.1010/a11-22\\(22\\)33v3"
 	
 	assert.EqualValues(t, expected, extracted)
 


### PR DESCRIPTION
Small change to DOI extraction to keep version numbers at the end.  This improves the chance of finding a match when the DOI belongs to a preprint.