### PR TITLE
Add date aggregations to federated publications

### DIFF
--- a/pkg/federated_search.go
+++ b/pkg/federated_search.go
@@ -250,6 +250,7 @@ func calculateAggregations(results PMCCoreResponse) gin.H {
 		d, err := time.Parse("2006", res.PubYear)
 		if err != nil {
 			slog.Info(fmt.Sprintf("Failed to convert year to date: %s", res.PubYear))
+			continue
 		}
 		if (d.Before(minDate)) {
 			minDate = d

--- a/pkg/federated_search_test.go
+++ b/pkg/federated_search_test.go
@@ -216,3 +216,25 @@ func TestBuildDoiQuery(t *testing.T) {
 	assert.Contains(t, queryString, "SRC:PPR")
 	assert.Contains(t, queryString, "PUB_YEAR:[2020%20TO%202021]")
 }
+
+func TestCalculateAggregations(t *testing.T) {
+	pmcCore := PMCCoreResponse{
+		ResultList: map[string][]PaperCore{
+			"result": {
+				{PubYear: "2020"},
+				{PubYear: "2002"},
+				{PubYear: "24"},
+			},
+		},
+	}
+
+	aggregations := calculateAggregations(pmcCore)
+
+	assert.Contains(t, aggregations, "startDate")
+	assert.Contains(t, aggregations, "endDate")
+	startDate := aggregations["startDate"].(gin.H)["value_as_string"].(string)
+	assert.EqualValues(t, startDate, "2002-01-01T00:00:00Z")
+	// Assert end date is "2020" which is latest valid end date passed
+	endDate := aggregations["endDate"].(gin.H)["value_as_string"].(string)
+	assert.EqualValues(t, endDate, "2020-01-01T00:00:00Z")
+}


### PR DESCRIPTION
https://hdruk.atlassian.net/browse/GAT-5541

Screenshot shows the date filter is now populated with dates for a federated search.

![Screenshot 2024-10-29 at 09 53 27](https://github.com/user-attachments/assets/0e9b6c6b-2b79-4608-a5c1-a4145ea720fc)
