### PR TITLE
New endpoint for multiple queries in fed pub search

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 
 	router.POST("/search/federated_papers/doi", search.DOISearch)
 	router.POST("/search/federated_papers/field_search", search.FieldSearch)
+	router.POST("/search/federated_papers/field_search/array", search.ArrayFieldSearch)
 
 	router.Run(os.Getenv("SEARCHSERVICE_HOST"))
 }


### PR DESCRIPTION
https://hdruk.atlassian.net/browse/GAT-5141

When an array of queries is posted to the federated publications search endpoint, the service fires off synchronous queries to EPMC for each element in the array. 

It then combines the results from each individual query, taking the top hit from each, then the second from each and so on.  EPMC doesn't returning relevance scores with search results so this is a simplistic attempt to order the results by relevance.