### PR TITLE
GAT-6300 :: Random ordering in search does not behave as expected under pagination

### DIFF
--- a/pkg/search.go
+++ b/pkg/search.go
@@ -176,13 +176,6 @@ func datasetSearch(query Query) SearchResponse {
 		)
 	}
 
-	prettyJSON, err := json.MarshalIndent(elasticQuery, "", " ")
-	if err != nil {
-		log.Fatalf("Error marshaling JSON: %v", err)
-	}
-
-	fmt.Println(string(prettyJSON))
-
 	response, err := ElasticClient.Search(
 		ElasticClient.Search.WithIndex("dataset"),
 		ElasticClient.Search.WithBody(&buf),


### PR DESCRIPTION
update elastic search with
```
PUT [elastic_search_server]/_cluster/settings

{
  "persistent": {
    "indices.id_field_data.enabled": true
  }
}
```

add env params:
```
SEARCH_NO_RECORDS=100
SEARCH_NO_RECORDS_AGGREGATION=1000
SEARCH_NO_RECORDS_SIMILAR_SEARCH=3
```
![Screenshot 2025-02-11 at 10 27 58](https://github.com/user-attachments/assets/33a74c16-a42c-4852-a671-40fe36097f5c)

![Screenshot 2025-02-11 at 10 29 00](https://github.com/user-attachments/assets/1303f2f3-b05f-463b-95dc-a07d881d0816)

