### PR TITLE
fix(GAT-6451): Update analyzers with character filter

### DIFF
--- a/pkg/settings.go
+++ b/pkg/settings.go
@@ -31,6 +31,9 @@ func DefineDatasetMappings(c *gin.Context) {
 								"lowercase",
 								"english_stemmer",
 							},
+							"char_filter": []string{
+								"punctuation_removal",
+							},
 						},
 						//search analyzer
 						"medterms_search_analyzer": gin.H{
@@ -39,6 +42,9 @@ func DefineDatasetMappings(c *gin.Context) {
 								"lowercase",
 								"medterms_synonyms",
 								"english_stemmer",
+							},
+							"char_filter": []string{
+								"punctuation_removal",
 							},
 						},
 					},
@@ -51,6 +57,13 @@ func DefineDatasetMappings(c *gin.Context) {
 							"type":         "synonym_graph",
 							"synonyms_set": "hdr_synonyms_set",
 							"updateable":   true,
+						},
+					},
+					"char_filter": gin.H{
+						"punctuation_removal": gin.H{
+							"type": "pattern_replace",
+							"pattern": "[^\\w\\s]",
+							"replacement": "",
 						},
 					},
 				},


### PR DESCRIPTION
Search will now ignore non-word/numeric characters, so "Co-stars" and "Costars" will return the same results.

https://hdruk.atlassian.net/browse/GAT-6451

![Screenshot 2025-04-25 at 14 53 43](https://github.com/user-attachments/assets/d12d9de3-db0e-45cc-81e8-b2a0ba836a84)
![Screenshot 2025-04-25 at 14 53 30](https://github.com/user-attachments/assets/da12ba95-a446-44f2-992b-10119d4e0a20)


Manual steps

```
DELETE <elastic-deployment>/dataset
POST <search-service>/mappings/datasets
php artisan app:reindex-entities datasets --chunkSize=20 --sleep=0.5
```
