### PR TITLE
feat(GAT-6380): Sanitise dataset name and tidy up query string in fed pub search

### DIFF
--- a/pkg/federated_search.go
+++ b/pkg/federated_search.go
@@ -253,23 +253,27 @@ func buildDoiQuery(query Query) string {
 }
 
 func buildQueryString(query FieldQuery) string {
-	queryString := "query=("
-	queryFormatted := strings.Replace(query.QueryString, " ", "%20", -1)
+	queryString := "query=(("
+	r := strings.NewReplacer(
+		" ", "%20",
+		"/", "",
+	)
+	queryFormatted := r.Replace(query.QueryString)
 	for i, fieldString := range(query.Field) {
 		if (i == (len(query.Field) - 1)) {
 			queryString = fmt.Sprintf(
-				"%s%s:%s)%%20AND%%20", queryString, fieldString, queryFormatted,
+				"%s%s:%s))", queryString, fieldString, queryFormatted,
 			)
 		} else {
 			queryString = fmt.Sprintf(
-				"%s%s:%s%%20OR%%20", queryString, fieldString, queryFormatted,
+				"%s%s:%s)%%20OR%%20(", queryString, fieldString, queryFormatted,
 			)
 		}
 	}
 	_, ok := query.Filters["paper"]
 	if ok {
 		filterString := getFilters(query.Filters)
-		fullString := fmt.Sprintf("%s%s", queryString, filterString)
+		fullString := fmt.Sprintf("%s%%20AND%%20%s", queryString, filterString)
 		return fullString
 	} else {
 		return queryString

--- a/pkg/federated_search_test.go
+++ b/pkg/federated_search_test.go
@@ -235,7 +235,7 @@ func TestArrayFieldSearch(t *testing.T) {
 
 func TestBuildQueryString(t *testing.T) {
 	query := FieldQuery{
-		QueryString: "A Very Useful Dataset (AVUD)",
+		QueryString: "A Very Useful / Dataset (AVUD)",
 		Field : []string{"TITLE","ABSTRACT","METHODS"},
 		Filters: map[string]map[string]interface{}{
 			"paper": {
@@ -251,6 +251,7 @@ func TestBuildQueryString(t *testing.T) {
 	assert.Contains(t, queryString, "PUB_TYPE:REVIEW")
 	assert.Contains(t, queryString, "SRC:PPR")
 	assert.Contains(t, queryString, "PUB_YEAR:[2020%20TO%202021]")
+	assert.NotContains(t, queryString, "/")
 }
 
 func TestBuildDoiQuery(t *testing.T) {


### PR DESCRIPTION
https://hdruk.atlassian.net/browse/GAT-6380

Turned out to be more of a bug fix. The federated publication search was already using keyword (as opposed to phrase) search but the query string construction was adding trailing "OR"s and "AND"s and it was failing when the dataset title contained `/`.